### PR TITLE
LoadAllSyntax when loading packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	cfg := &packages.Config{Mode: packages.LoadSyntax}
+	cfg := &packages.Config{Mode: packages.LoadAllSyntax}
 	pkgs, err := packages.Load(cfg, os.Args[1:]...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "load: %v\n", err)


### PR DESCRIPTION
LoadAllSyntax when loading packages, though this is not necessary as we don't analyze the dependencies, while:

- This can help when we later extend it to supporting pandora sdk
- Fix #1